### PR TITLE
Fix corrupt link of rawgit.

### DIFF
--- a/img2url/remotes/github.py
+++ b/img2url/remotes/github.py
@@ -263,6 +263,6 @@ class GitHubOperation(OperationPackage):
 
     def resource_url(self, fname, hash_tag):
         URL = (
-            'https://cdn.rawgit.com/{user}/{repo}/{branch}/{path}{filename}'
+            'https://raw.githubusercontent.com/{user}/{repo}/{branch}/{path}{filename}'
         )
         return URL.format(filename=fname, **self.config.fields)


### PR DESCRIPTION
RawGit has reached the end of its useful life.
Access to https://cdn.rawgit.com/ will result in "403 Forbidden".
This PR changes cdn.rawgit.com to raw.githubusercontent.com.
